### PR TITLE
[ADD] 19236 Java Solution

### DIFF
--- a/baekjoon/week1/19236/[19236] 청소년 상어_김세진.java
+++ b/baekjoon/week1/19236/[19236] 청소년 상어_김세진.java
@@ -1,0 +1,177 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class prob19236 {
+    // 좌표 클래스
+    static class xy {
+        int x;
+        int y;
+
+        xy(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    // 물고기 클래스
+    static class Fish extends xy {
+        boolean alive;
+        int num;
+        int direction;
+
+        public Fish(int x, int y, boolean alive, int num, int direction) {
+            super(x, y);
+            this.alive = alive;
+            this.num = num;
+            this.direction = direction;
+        }
+
+        // 물고기 복사 메서드 (deep copy)
+        public Fish FishCopy() {
+            return new Fish(this.x, this.y, this.alive, this.num, this.direction);
+        }
+    }
+
+    static int[] d_row = { -1, -1, 0, 1, 1, 1, 0, -1 };
+    static int[] d_col = { 0, -1, -1, -1, 0, 1, 1, 1 };
+    static ArrayList<Fish> fishList = new ArrayList<>();
+    static int ans = 0;
+    static Fish initFish;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        for (int i = 0; i < 4; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 4; j++) {
+                int num = Integer.parseInt(st.nextToken());
+                int direction = Integer.parseInt(st.nextToken());
+                Fish fish = new Fish(i, j, true, num, direction - 1);
+
+                // 초기 위치 물고기
+                if (i == 0 && j == 0) {
+                    initFish = fish;
+                }
+
+                fishList.add(fish);
+            }
+        }
+        // 물고기 번호 순 정렬
+        fishList.sort(new Comparator<Fish>() {
+            @Override
+            public int compare(Fish o1, Fish o2) {
+                return o1.num - o2.num;
+            }
+        });
+
+        initFish.alive = false;
+        // 백트래킹
+        BackTracking(new xy(0, 0), initFish.direction, initFish.num, fishList);
+        // 출력
+        System.out.println(ans);
+    }
+
+    private static void BackTracking(xy sharkPos, int sharkDirection, int eatenFishCnt, List<Fish> nowFishList) {
+        // 물고기 리스트 복사
+        List<Fish> CopyFishList = MoveFishes(sharkPos, nowFishList);
+
+        // 먹을 수 있는 물고기 탐색 
+        Queue<Fish> TargetFishQueue = SearchPossibleEatFish(sharkPos, sharkDirection, CopyFishList);
+
+        // 먹을 수 있는 물고기가 없다면 분기 종료 (기저조건)
+        if (TargetFishQueue.isEmpty()) {
+            ans = Math.max(ans, eatenFishCnt);
+            return;
+        }
+
+        // 백트래킹 (유도부분)
+        while (!TargetFishQueue.isEmpty()) {
+            Fish targetFish = TargetFishQueue.poll();
+
+            targetFish.alive = false;
+            BackTracking(new xy(targetFish.x, targetFish.y), targetFish.direction, targetFish.num + eatenFishCnt,
+                    CopyFishList);
+            targetFish.alive = true;
+        }
+    }
+
+    // 먹을 수 있는 물고기 탐색 메서드
+    private static Queue<Fish> SearchPossibleEatFish(xy sharkPos, int sharkDirection, List<Fish> copyFishList) {
+        Queue<Fish> ret = new LinkedList<>();
+        int newSharkX = sharkPos.x + d_row[sharkDirection];
+        int newSharkY = sharkPos.y + d_col[sharkDirection];
+
+        while (!IsOutBound(newSharkX, newSharkY)) {
+            for (Fish fish : copyFishList) {
+                if (newSharkX == fish.x && newSharkY == fish.y && fish.alive) {
+                    ret.add(fish);
+                    break;
+                }
+            }
+            newSharkX += d_row[sharkDirection];
+            newSharkY += d_col[sharkDirection];
+        }
+
+        return ret;
+    }
+
+    // 물고기 이동 메서드 (이동된 결과를 반환)
+    private static List<Fish> MoveFishes(xy sharkPos, List<Fish> nowFishList) {
+        // 물고기 리스트 복사
+        List<Fish> CopyFishList = new ArrayList<>();
+        for (Fish fish : nowFishList) {
+            CopyFishList.add(fish.FishCopy());
+        }
+
+        for (Fish fish : CopyFishList) {
+            if (!fish.alive) {
+                continue;
+            }
+
+            // 살아있다면 이동
+            for (int j = 0; j < 8; j++) {
+                int direction = (fish.direction + j) % 8;
+                int newFishX = fish.x + d_row[direction];
+                int newFishY = fish.y + d_col[direction];
+
+                // 해당 방향이 이동 가능하다면 이동
+                if (IsPossibleFishMove(newFishX, newFishY, sharkPos)) {
+                    fish.direction = direction;
+                    for (Fish newFish : CopyFishList) {
+                        if (newFish.x == newFishX && newFish.y == newFishY) {
+                            int tmpX = fish.x;
+                            int tmpY = fish.y;
+                            fish.x = newFishX;
+                            fish.y = newFishY;
+                            newFish.x = tmpX;
+                            newFish.y = tmpY;
+                            break;
+                        }
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return CopyFishList;
+    }
+
+    // 물고기 이동가능 여부
+    private static boolean IsPossibleFishMove(int newFishX, int newFishY, xy sharkPos) {
+        return !IsOutBound(newFishX, newFishY) && (newFishX != sharkPos.x || newFishY != sharkPos.y);
+    }
+
+    private static boolean IsOutBound(int x, int y) {
+        return x < 0 || x >= 4 || y < 0 || y >= 4;
+    }
+}


### PR DESCRIPTION
# 문제
[19236 청소년상어](https://www.acmicpc.net/problem/19236)
# 작성자
[tpwls1355](https://www.acmicpc.net/user/tpwls1355)
# 문제풀이
4x4 공간에서 상어의 모든 이동 경우를 판단하는 완전탐색 문제입니다.
각 물고기는 고유의 이동방향을 가지고 이동하고 모든 물고기의 이동이 끝나면 상어가 이동합니다.
상어는 맵 상의 물고기가 있는 칸에만 이동할 수 있습니다.
가능한 상어의 이동경로들 중에서 물고기 번호 합이 가장 큰 경우를 출력합니다.

물고기의 정보를 담는 Fish클래스를 정의했습니다. 멤버 변수로는 번호, 이동방향, 좌표, 생존여부가 있습니다.

물고기는 항상 번호 순대로 이동하기 때문에 List에 각 객체를 넣어 정렬한 뒤 사용했습니다.

물고기의 이동 결과는 기존의 리스트를 복사한 리스트에 저장하여 반환합니다. 이는 재귀의 다음 탐색이 영향을 미치지 않게 하기 위해서입니다.

물고기의 이동은 상어의 위치를 확인하며 반시계로 돌아가며 판단합니다. 가능한 이동 방향이라면 해당 위치의 물고기와 위치를 스왑합니다.

상어의 이동은 재귀를  이용한 백트래킹 구조로 된 메서드로 수행됩니다. 항상 상어는 물고기가 모두 이동한 뒤 움직일 수 있기 때문에 메서드 진입 시에 물고기를 우선적으로 이동시킵니다.

물고기 이동이 끝나면 상어가 이동할 수 있는 칸을 탐색합니다. 상어는 이전에 먹은 물고기의 방향으로만 움직일 수 있습니다. 따라서, 해당 방향을 따라서 움직이면서 이동가능여부를 판단합니다. 가능한 칸의 물고기 정보를 큐에 저장하여 백트래킹의 유도부분으로 사용합니다.

하지만, 탐색이 끝나고 큐에 저장된 물고기가 없다면 이동이 불가능하다는 뜻이기 때문에 분기를 종료합니다. 이 때가 재귀의 기저조건이 됩니다.

유도부분에서는 물고기 큐를 통해 재귀를 수행합니다. 재귀에 필요한 정보는 다음과 같습니다.
> 1. 갱신된 상어의 위치 (먹은 물고기 위치)
> 2. 갱신된 상어의 방향 (먹은 물고기 방향)
> 3. 현재까지 먹은 물고기들의 번호 합
> 4. 상어의 이동으로 갱신된 물고기 리스트

# 유의점
백트래킹을 수행하는 과정에서 물고기의 이동에 따라 리스트 정보가 바뀌기 때문에 이를 처리하는 과정이 어려웠습니다.

처음에 전역으로 선언된 Fish클래스형 리스트를 사용했습니다. 백트래킹 과정에서는 이후 depth에서의 수행이 현재에 영향을 미치면 안됩니다. 하지만 위와 같은 자료구조에서 객체를 그냥 대입하는 방식으로 값을 수정하면 현재의 리스트까지 영향을 미칩니다.

이를 해결하기 위해 깊은 복사된 리스트를 재귀의 인자로 넘기는 방식을 선택했습니다. 복사하기 위해 재귀 메서드를 수행할 때마다 넘겨받은 물고기 리스트를 모두 순회해야 했지만 리스트의 크기가 다소 작기 때문에 큰 문제가 되진 않았습니다.