### PR TITLE
[ADD] 15684 C++ Solution

### DIFF
--- a/baekjoon/week1/15684/[15684] 사다리 조작_서정운.cpp
+++ b/baekjoon/week1/15684/[15684] 사다리 조작_서정운.cpp
@@ -1,0 +1,73 @@
+
+#pragma GCC optimize("Ofast")
+#pragma GCC optimize("unroll-loops")
+
+#include <bits/stdc++.h>
+using namespace std;
+
+using ll = long long;
+using ii = pair<int, int>;
+
+#define For(i,a,b) for(int i=a;i<b;i++)
+#define outside(x,y,R,C) (min(x,y) < 0 || x >=R || y >= C)
+#define FAST (cin.tie(0)->sync_with_stdio(0))
+#define nx(x,i) ("0121"[i] - '1' + x)
+#define ny(y,i) ("1210"[i] - '1' + y)
+#define endl '\n'
+#define all(v) v.begin(), v.end()
+#define rall(v) v.rbegin(), v.rend()
+
+
+int ladder[33][11];
+int N, M, H;
+
+int res = 1e9;
+
+bool check() {
+	For(i, 1, N + 1) {
+		int now = i;
+		For(j, 1, H + 1) {
+			if (ladder[j][now]) now++;
+			else if (ladder[j][now - 1]) now--;
+		}
+		if (now != i) return false;
+	}
+	return true;
+}
+
+void dfs(int pos, int cnt) {
+
+	int x = pos / (N - 1) + 1, y = pos % (N - 1) + 1;
+
+	if (check()) {
+		res = min(res, cnt);
+	}
+
+	if (cnt >= min(res, 3)) return;
+	if (x > H) return;
+
+	dfs(pos + 1, cnt);
+	if (!(ladder[x][y - 1] || ladder[x][y] || ladder[x][y + 1])) {
+		ladder[x][y] = 1;
+		dfs(pos + 1, cnt + 1);
+		ladder[x][y] = 0;
+	}
+
+}
+
+int main() {
+	FAST;
+
+	cin >> N >> M >> H;
+
+	For(i, 0, M) {
+		int a, b; cin >> a >> b;
+		ladder[a][b] = 1;
+	}
+
+	dfs(0, 0);
+
+	if (res == 1e9) res = -1;
+	cout << res;
+
+}


### PR DESCRIPTION
# [사다리 조작](https://www.acmicpc.net/problem/15684)

구현, 시뮬레이션
+ 조합론, 브루트포스

## 풀이

가능한 사다리 조합들에 대해, 모든 사다리의 시작점이 동일한 도착점을 가리킬 때, 최소 사다리 개수를 구하는 문제.

DFS 굴려도 되고, 3중 반복문으로 풀어도 된다. 여기선 DFS로 풀이했다.

사다리 조합을 만들 때, 같은 행에서 사다리 2개가 연달아 붙지 않도록 유의해야 한다.

가능한 사다리 개수가 약 300개이고, 그 중 3가지를 고르는 것이므로 $_{300}C_3$,  약 450만 가지 조합이 존재한다.
이 때, 사다리가 연이어 붙은 경우는 제외해야 하므로, 열의 개수를 절반으로 생각하고 계산하면 약 50만 가지 조합로 줄어든다.
사다리를 1개, 2개를 고르는 가짓수도 존재하지만, 3개보다는 개수가 크게 적으므로 건너뛴다.

각 조합마다, 사다리의 시작점과 도착점이 같은지 검사한다. 각 열마다, 행 개수만큼 검사를 진행하므로 검사 시 300회의 연산이 필요하다.

각 조합마다 300회의 연산이 수행되고, 조합이 50만 가지이므로 최대 1억 5천만 회의 연산이 수행된다. 이는 실행시간 2초 내로 충분히 연산이 가능하다.

## 리뷰

이전에도 한번 풀어봤던 문제인데, 그 땐 조합론에 약해서 못 풀었었다.
한 번 풀어보기 정말 좋은 문제라고 생각한다.