### PR TITLE
[ADD] 15685 Java Solution

### DIFF
--- a/baekjoon/week3/15685/[15685] 드래곤 커브_김세진.java
+++ b/baekjoon/week3/15685/[15685] 드래곤 커브_김세진.java
@@ -1,0 +1,81 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class prob15685 {
+    static int N;
+    static boolean[][] map = new boolean[101][101];
+    static int[] d_y = { 0, -1, 0, 1 };
+    static int[] d_x = { 1, 0, -1, 0 };
+    static int cnt = 0;
+
+    public static void main(String[] args) throws NumberFormatException, IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int startX = Integer.parseInt(st.nextToken());
+            int startY = Integer.parseInt(st.nextToken());
+            int d = Integer.parseInt(st.nextToken());
+            int g = Integer.parseInt(st.nextToken());
+
+            List<Integer> routeList = new ArrayList<>(); // 드래곤 커브의 전체 동선을 저장할 리스트
+            routeList.add(d); // 0세대 동선 저장
+            int endX = startX + d_x[d];
+            int endY = startY + d_y[d];
+            map[endY][endX] = true;
+            map[startY][startX] = true;
+
+            // 1세대부터 커브 그리기
+            for (int j = 1; j <= g; j++) {
+                // 새로운 끝점 (시계 방향 회전)
+                int dX = startX - endX;
+                int dY = startY - endY;
+                int tmpX = endX -= dY;
+                int tmpY = endY += dX;
+                map[tmpY][tmpX] = true;
+
+                List<Integer> tmpList = new ArrayList<>(); // 새롭게 그릴 커브 동선
+                for (int direction : routeList) {
+                    int newDirection = (direction + 3) % 4; // 방향 벡터가 반시계이기 때문에 반대로 (시계)
+                    tmpList.add(newDirection);
+                    tmpX += d_x[newDirection];
+                    tmpY += d_y[newDirection];
+
+                    map[tmpY][tmpX] = true;
+                }
+
+                // 새롭게 그린 커브 동선을 뒤에서부터, 방향은 반대로, 전체 동선 리스트에 저장
+                for (int k = tmpList.size() - 1; k >= 0; k--) {
+                    routeList.add((tmpList.get(k) + 2) % 4);
+                }
+            }
+        }
+
+        for (int i = 0; i < 100; i++) {
+            for (int j = 0; j < 100; j++) {
+                if (!map[i][j]) {
+                    continue;
+                }
+                if (!map[i + 1][j]) {
+                    continue;
+                }
+                if (!map[i][j + 1]) {
+                    continue;
+                }
+                if (!map[i + 1][j + 1]) {
+                    continue;
+                }
+                cnt++;
+            }
+        }
+
+        System.out.println(cnt);
+    }
+}


### PR DESCRIPTION
# 문제
[15685 드래곤 커브](https://www.acmicpc.net/problem/15685)
# 작성자
[tpwls1355](https://www.acmicpc.net/user/tpwls1355)
# 문제 풀이
드래곤 커브는 간단하게 이전 세대까지 그린 커브를 시계 방향으로 회전한 것을 다시 그리면 됩니다.

다시 말해, N세대는 N-1세대의 그린 그림을 시계 회전한 뒤 합친 것입니다.

드래곤 커브를 그리기 위해 전체 동선은 저장할 리스트를 자료구조로 사용했습니다. 저장될 동선은 시작점부터의 방향 벡터 집합입니다.

새롭게 그릴 커브는 두 가지 방법으로 그릴 수 있습니다.
### 1. 이전 세대 끝 점부터 그리기
이전 세대의 끝 점부터 그리기 시작합니다. 그릴 동선은 리스트를 뒤에서 읽은 방향을 반시계 방향으로 회전해야 합니다.

### 2. 현 세대 끝 점부터 그리기
현 세대의 끝 점을 먼저 찍고 해당 점부터 그리기 시작합니다. 그릴 동선은 리스트를 앞에서 읽은 방향을 시계 방향으로 회전해야 합니다.

1번의 방법이 그리면서 전체 리스트에 동선을 저장할 수 있기 때문에 효율적으로 보입니다.
본인은 2번 방법을 먼저 떠올려서 해당 방법으로 풀이하였습니다.
# 유의점
2차원 좌표 평면이 y축이 세로축이면서 아래가 증가하는 방향, x축은 가로축이면서 오른쪽이 증가하는 방향입니다. 이를 유의해서 맵의 인덱스를 처리할 필요가 있습니다. 

주어지는 입력 방향이 0~3으로 반시계로 되어있기 때문에 시계방향 회전을 하기 위해 유의하여 작성해야합니다.