### PR TITLE
[ADD] 14891 Java Solution

### DIFF
--- a/baekjoon/week3/14891/[14891] 톱니바퀴_김세진.java
+++ b/baekjoon/week3/14891/[14891] 톱니바퀴_김세진.java
@@ -1,0 +1,101 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class prob14891 {
+  static List<Integer>[] gearList = new ArrayList[5];
+  static int K;
+
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    for (int i = 1; i <= 4; i++) {
+      gearList[i] = new ArrayList<>();
+
+      String s = br.readLine();
+      for (int j = 0; j < 8; j++) {
+        gearList[i].add(s.charAt(j) - '0');
+      }
+    }
+
+    K = Integer.parseInt(br.readLine());
+    for (int i = 0; i < K; i++) {
+      StringTokenizer st = new StringTokenizer(br.readLine());
+      int gearNum = Integer.parseInt(st.nextToken());
+      int direction = Integer.parseInt(st.nextToken());
+
+      // 왼쪽 사이드 기어 회전 (재귀)
+      if (gearNum - 1 > 0) {
+        if (gearList[gearNum - 1].get(2) != gearList[gearNum].get(6)) {
+          RotateGearLeft(gearNum - 1, direction * (-1));
+        }
+      }
+
+      // 오른쪽 사이드 기어 회전 (재귀)
+      if (gearNum + 1 <= 4) {
+        if (gearList[gearNum + 1].get(6) != gearList[gearNum].get(2)) {
+          RotateGearRight(gearNum + 1, direction * (-1));
+        }
+      }
+
+      // 다른 회전이 끝나면 본 기어 회전
+      if (direction == 1) {
+        int tmp = gearList[gearNum].get(7);
+        gearList[gearNum].remove(7);
+        gearList[gearNum].add(0, tmp);
+      } else {
+        int tmp = gearList[gearNum].get(0);
+        gearList[gearNum].remove(0);
+        gearList[gearNum].add(tmp);
+      }
+    }
+
+    int score = 0;
+    for (int i = 1; i <= 4; i++) {
+      score += (gearList[i].get(0)) * Math.pow(2, i - 1);
+    }
+
+    System.out.println(score);
+  }
+
+  private static void RotateGearRight(int gearNum, int direction) {
+    if (gearNum + 1 <= 4) {
+      if (gearList[gearNum + 1].get(6) != gearList[gearNum].get(2)) {
+        RotateGearRight(gearNum + 1, direction * (-1));
+      }
+    }
+
+    if (direction == 1) {
+      int tmp = gearList[gearNum].get(7);
+      gearList[gearNum].remove(7);
+      gearList[gearNum].add(0, tmp);
+    } else {
+      int tmp = gearList[gearNum].get(0);
+      gearList[gearNum].remove(0);
+      gearList[gearNum].add(tmp);
+    }
+  }
+
+  private static void RotateGearLeft(int gearNum, int direction) {
+    if (gearNum - 1 > 0) {
+      if (gearList[gearNum - 1].get(2) != gearList[gearNum].get(6)) {
+        RotateGearLeft(gearNum - 1, direction * (-1));
+      }
+    }
+
+    if (direction == 1) {
+      int tmp = gearList[gearNum].get(7);
+      gearList[gearNum].remove(7);
+      gearList[gearNum].add(0, tmp);
+    } else {
+      int tmp = gearList[gearNum].get(0);
+      gearList[gearNum].remove(0);
+      gearList[gearNum].add(tmp);
+    }
+  }
+}


### PR DESCRIPTION
# 문제
[14891 톱니바퀴](https://www.acmicpc.net/problem/14891)
# 작성자
[tpwls1355](https://www.acmicpc.net/user/tpwls1355)
# 문제 풀이
총 4개의 톱니를 회전하는 시뮬레이션 문제입니다. 톱니에는 N극과 S극이 있으며 만일 인접한 톱니와 극성이 다른 경우 같이 회전하게 되고 같은 경우에는 회전하지 않습니다.

회전 방향은 영향을 미친 톱니의 반대 방향입니다. 1번 톱니가 시계 회전한다면 2번이 회전할 때는 반시계 회전해야 합니다.

톱니의 위치는 문자열로 표시되는데 본 코드에서는 리스트를 사용했습니다. 회전을 해야 했기 때문에 큐 혹은 리스트를 사용해야 했습니다. 톱니를 회전할 때마다 3시 톱니, 9시 톱니의 극성을 수시로 확인해야 했기 때문에 인덱스 참조가 가능한 리스트를 선택했습니다.

회전 메서드는 재귀적으로 구현했습니다. 4번 톱니가 돌 때 이 영향으로 1번 톱니까지 돌 수 있습니다. 또한, 4번의 회전으로 회전될 왼쪽 톱니가 회전하기 전까지는 4번이 회전하면 안됩니다. 왜냐하면 4번의 회전으로 다른 톱니의 회전여부가 바뀔 수 있기 때문입니다.

회전은 리스트의 요소를 꺼내 끝에 삽입하거나 0 위치에 삽입함으로써 구현했습니다.

# 유의점