### PR TITLE
[ADD] 21611 C++ Solution

### DIFF
--- a/baekjoon/week3/21611/[21611] 마법사 상어와 블리자드_서정운.cpp
+++ b/baekjoon/week3/21611/[21611] 마법사 상어와 블리자드_서정운.cpp
@@ -1,0 +1,178 @@
+#pragma GCC optimize("Ofast")
+#pragma GCC optimize("unroll-loops")
+
+#include <bits/stdc++.h>
+using namespace std;
+
+using ll = long long;
+using ii = pair<int, int>;
+
+#define For(i,a,b) for(int i=a;i<b;i++)
+#define endl '\n'
+#define all(v) v.begin(), v.end()
+#define rall(v) v.rbegin(), v.rend()
+//constexpr inline auto nx = [](int x, int i) -> int {return "0121"[i] - '1' + x; };
+//constexpr inline auto ny = [](int y, int i) -> int {return "1210"[i] - '1' + y; };
+//constexpr inline auto outside = [](int x, int y, int R, int C) -> bool {return (min(x, y) < 0 || x >= R || y >= C); };
+constexpr inline auto FAST = []() -> void {cin.tie(0)->sync_with_stdio(0); };
+
+
+deque<int> q;
+int board[55][55];
+
+int N, M;
+
+ll score = 0;
+
+// 12시부터 반시계방향
+int nx(int x, int i) {
+    return "0121"[i] - '1' + x;
+}
+
+int ny(int y, int i) {
+    return "1012"[i] - '1' + y;
+}
+
+bool outside(int x, int y, int R, int C) {
+    return min(x, y) < 0 || x >= R || y >= C;
+}
+
+// 상하좌우에서 바꾸기
+int dirconvert(int d) {
+    if (d == 1) return 0;
+    if (d == 2) return 2;
+    if (d == 3) return 1;
+    return 3;
+}
+
+vector<pair<int, int>> pos;
+
+void init() {
+    int x, y;
+    x = y = N / 2;
+
+    int dir = 3;
+    For(i, 0, N + 1) {
+        For(j, 0, i) {
+            x = nx(x, dir); y = ny(y, dir);
+            if (outside(x, y, N, N)) return;
+            pos.push_back({ x,y });
+        }
+        dir = (dir + 1) % 4;
+        For(j, 0, i) {
+            x = nx(x, dir); y = ny(y, dir);
+            if (outside(x, y, N, N)) return;
+            pos.push_back({ x,y });
+        }
+        dir = (dir + 1) % 4;
+    }
+}
+
+void remove(int d, int s) {
+    int size = q.size();
+
+    int cnt = 0;
+    for (int i = 0; i < size; i++) {
+        int now = q.front(); q.pop_front();
+        auto p = pos[i];
+        // 아직 덜 지웠다면, 
+        if (cnt < s) {
+            // 위, 아래
+            if (d == 0 || d == 2) {
+                // 상어 열일 때,
+                if (p.second == N / 2) {
+                    if (d == 0 && p.first < N / 2) {
+                        cnt++; continue;
+                    }
+                    if (d == 2 && p.first > N / 2) {
+                        cnt++; continue;
+                    }
+                }
+            }
+            // 좌, 우
+            if (d == 1 || d == 3) {
+                // 상어 행일 때,
+                if (p.first == N / 2) {
+                    if (d == 1 && p.second < N / 2) {
+                        cnt++; continue;
+                    }
+                    if (d == 3 && p.second > N / 2) {
+                        cnt++; continue;
+                    }
+                }
+            }
+        }
+        q.push_back(now);
+    }
+}
+
+void compress() {
+    int target, cnt;
+    target = -1, cnt = 0;
+    deque<pair<int, int>> tmp, tmp2;
+    while (q.size()) {
+        int now = q.front(); q.pop_front();
+        if (target != now) {
+            if (target != -1) tmp.push_back({ target, cnt });
+            target = now; cnt = 1;
+        }
+        else cnt++;
+    }
+    if (target != -1) tmp.push_back({ target, cnt });
+
+    while (true) {
+        bool flag = false;
+        for (int t = tmp.size(); t--;) {
+            auto now = tmp.front(); tmp.pop_front();
+            if (now.second >= 4) {
+                score += now.first * now.second;
+                flag = true; continue;
+            }
+            if (tmp2.size() && tmp2.back().first == now.first) {
+                tmp2.back().second += now.second;
+            }
+            else tmp2.push_back(now);
+        }
+        swap(tmp, tmp2);
+        if (!flag) break;
+    }
+
+    while (tmp.size()) {
+        q.push_back(tmp.front().second);
+        q.push_back(tmp.front().first);
+        tmp.pop_front();
+        if (q.size() >= pos.size()) break;
+    }
+
+    while (q.size() > pos.size()) q.pop_back();
+
+}
+
+int main() {
+
+    cin >> N >> M;
+
+    For(i, 0, N) For(j, 0, N) cin >> board[i][j];
+
+    init();
+
+    for (auto p : pos) {
+        if (board[p.first][p.second] == 0) break;
+        q.push_back(board[p.first][p.second]);
+    }
+
+    For(i, 0, M) {
+        int d, s; cin >> d >> s;
+        remove(dirconvert(d), s);
+        compress();
+
+        //cout << "===DEBUG===" << endl;
+        //for (int t = q.size(); t--;) {
+        //    cout << q.front() << ' '; q.push_back(q.front()); q.pop_front();
+        //}
+        //cout << endl;
+    }
+
+    cout << score;
+
+}


### PR DESCRIPTION
# [마법사 상어와 블리자드](https://www.acmicpc.net/problem/21611)

구현, 시뮬레이션

### 풀이

큐를 이용해서 풀었다.

### 준비

우선 포인터를 빙빙 돌리면서 각 요소들의 위치를 기록하는 pos 벡터를 미리 생성해두었다.

### 블리자드

remove 함수에서 블리자드를 수행한다.
큐의 요소를 하나씩 꺼내면서, 블리자드 범위에 속하는 요소라면 건너뛰는 식으로 구현했다.
이 때 파괴되는 구슬은 점수에 포함되지 않는다.

### 구슬 터뜨리기

compress 함수에서 구슬을 터뜨리고 변화시키는 일을 한다.

우선 각 구슬을 그룹으로 묶어내는 작업을 수행한다. pair<int, int>를 활용하였으며, 왼쪽은 구슬의 종류, 오른쪽엔 구슬의 개수를 기록했다.

이후 구슬을 터뜨리는 작업을 수행한다. 그룹 큐를 순회하면서, 구슬의 개수가 4개 이상이라면 해당 그룹을 제거하는 식으로 구현했다.
이 때 제거되는 구슬들은 점수 계산에 포함하여야 한다.

구슬을 넣을 때, 동일한 종류의 그룹이 큐의 뒤에 존재한다면, 두 그룹을 합친다.

더 이상 터지는 구슬이 존재하지 않을 때까지 위의 작업을 반복 수행한다.

### 변화시키기

구슬이 터지지 않았다면, 이제 기존의 구슬 큐에 구슬들을 집어넣는다. 구슬의 개수와 구슬의 종류 순서로 큐에 집어넣는다.

## 리뷰

구슬을 폭발시킬 때, 구슬을 폭발시키면서 갱신하면 문제의 의도와 다르게 갱신된다.
구슬을 모두 폭발시킨 뒤 합치고, 다시 폭발시키는 작업이 필요하다.

아래와 같이 구슬이 존재하는 경우, 잘못 갱신되는 경우가 발생한다.
```
111 2222 111 2222 1

// 제대로 갱신하는 경우, 큐가 비게 된다.
- 111 " " 111 " " 1
- " "

// 잘못 갱신하는 경우, 1이 남는다.
- 111 " " 11122221
- " " 22221
- " " 1
- 1
```